### PR TITLE
Corrects module name

### DIFF
--- a/danger-prose.gemspec
+++ b/danger-prose.gemspec
@@ -5,7 +5,7 @@ require 'version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'danger-prose'
-  spec.version       = Prose::VERSION
+  spec.version       = DangerProse::VERSION
   spec.authors       = ['David Grandinetti', 'Orta Therox']
   spec.email         = ['dbgrandi@gmail.com', 'orta.therox@gmail.com']
   spec.description   = %q{A danger plugin for working with bodies of markdown prose.}


### PR DESCRIPTION
My guess is that it was first introduced in https://github.com/dbgrandi/danger-proselint/commit/9cac8d9ead86d082fd769cddef1474c3d44622df When trying to install the gem, this was the error:

```
There was a NameError while loading danger-prose.gemspec:
uninitialized constant Prose from
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/danger-proselint-2eedcbe2d8f1/danger-prose.gemspec:8:in `block in <main>'
```
