### PR TITLE
Fix typo in module name

### DIFF
--- a/lib/proselintrc
+++ b/lib/proselintrc
@@ -37,7 +37,7 @@
         "misc.many_a"                   : true,
         "misc.metaconcepts"             : true,
         "misc.metadiscourse"            : true,
-        "misc.narcisissm"               : true,
+        "misc.narcissism"               : true,
         "misc.not_guilty"               : true,
         "misc.phrasal_adjectives"       : true,
         "misc.preferred_forms"          : true,


### PR DESCRIPTION
This fixes a typo in the module name for `misc.narcissism`.
