### PR TITLE
Prevent empty proselint report section while there is no error

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -60,7 +60,7 @@ module Danger
       with_proselint_disabled(to_disable) do
         # Convert paths to proselint results
         result_jsons = Hash[markdown_files.uniq.collect { |v| [v, get_proselint_json(v)] }]
-        proses = result_jsons.select { |_, prose| prose['data']['errors'].count }
+        proses = result_jsons.select { |_, prose| prose['data']['errors'].count > 0 }
       end
 
       # Get some metadata about the local setup


### PR DESCRIPTION
I was recently playing around with danger-prose, and I found the plugin print a **Proselint found issues** section with nothing in the table. That happens every time as long as I turn `prose.lint_files` on in my `Dangerfile`.

It turned out that the `result_jsons.select` call on L63 didn't really work: it filtered nothing, at lease not on my Ruby 2.4.0. 

This fix explicitly returns if `prose['data']['errors'].count > 0`, and it should make the `select` call work again.