### PR TITLE
Added options to ignore numbers and acronyms

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -103,6 +103,18 @@ module Danger
     # defaults to `[""]` when it's nil.
     # @return [Array<String>]
     attr_accessor :ignored_words
+    
+    # Allows you to specify that you want to ignore reporting numbers
+    # as spelling errors. Defaults to `false`, switch it to `true`
+    # if you wish to ignore numbers.
+    # @return false
+    attr_accessor :ignore_numbers
+    
+    # Allows you to specify that you want to ignore acronyms as spelling
+    # errors. Defaults to `false`, switch it to `true` if you wish
+    # to ignore acronyms.
+    # @return false
+    attr_accessor :ignore_acronyms
 
     # Runs a markdown-specific spell checker, against a corpus of `.markdown` and `.md` files.
     #
@@ -121,9 +133,14 @@ module Danger
 
       markdown_files = get_files files
 
+      arguments = ["-r"]
       skip_words = ignored_words || []
+
+      arguments.push("-n") if ignore_numbers
+      arguments.push("-a") if ignore_acronyms
+
       File.write(".spelling", skip_words.join("\n"))
-      result_texts = Hash[markdown_files.to_a.uniq.collect { |md| [md, `mdspell #{md} -r`.strip] }]
+      result_texts = Hash[markdown_files.to_a.uniq.collect { |md| [md, `mdspell #{md} #{arguments.join(" ")}`.strip] }]
       spell_issues = result_texts.select { |path, output| output.include? "spelling errors found" }
       File.unlink(".spelling")
 


### PR DESCRIPTION
I tried my best to add options to disable treating numbers and acronyms as spelling errors, as requested in issue #24 and as required for a few projects of mine. Unfortunately, I am not very familiar with the Ruby world so I was not actually able to test that this works outside of local `irb` test, so I apologise in advance if I made any mistake 🙏 Hopefully it's at least a start, fingers crossed.